### PR TITLE
Make metadata and contact in the response surveymonkey model optional since SurveyMonkey no longer returns these

### DIFF
--- a/gsheets-workflow-api/lib/survey_monkey/response.py
+++ b/gsheets-workflow-api/lib/survey_monkey/response.py
@@ -9,11 +9,11 @@ class CustomValue(BaseModel):
 
 
 class Contact(BaseModel):
-    custom_value: CustomValue
+    custom_value: Optional[CustomValue]
 
 
 class Metadata(BaseModel):
-    contact: Contact
+    contact: Optional[Contact]
 
 
 class Answer(BaseModel):


### PR DESCRIPTION
This resolves the following issue:

```
D      refresh_surveys_and_combined_listings  72lpackju9s1  2023-06-28 07:22:23.268  Function execution took 118418 ms, finished with status: 'crash'
       refresh_surveys_and_combined_listings  72lpackju9s1  2023-06-28 07:22:23.266    field required (type=value_error.missing)
       refresh_surveys_and_combined_listings  72lpackju9s1  2023-06-28 07:22:23.266  metadata -> contact -> custom_value
E      refresh_surveys_and_combined_listings  72lpackju9s1 
```